### PR TITLE
Make plotly.saveImage return a callback when it has finished successfully.

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,12 +176,7 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
 
 Plotly.prototype.saveImage = function (figure, path, callback) {
   var self = this;
-  if(!callback) {
-    callback = function(err) {
-      if(err) { console.error(err); }
-      else { console.log('image saved!') ;}
-    };
-  }
+  if(!callback) { callback = function() {}; }
   figure = JSON.stringify(figure);
 
   var headers = {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ Plotly.prototype.plot = function(data, graphOptions, callback) {
           error: body.error
         });
       }
-      
+
     });
   });
 
@@ -167,7 +167,7 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
         var figure = JSON.parse(body).payload.figure;
         callback(null, figure);
       }
-      
+
     })
   });
 
@@ -176,6 +176,12 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
 
 Plotly.prototype.saveImage = function (figure, path, callback) {
   var self = this;
+	if(!callback) {
+		callback = function(err) {
+			if(err) { console.error(err); }
+			else { console.log('image saved!') ;}
+		};
+	}
   figure = JSON.stringify(figure);
 
   var headers = {
@@ -206,9 +212,9 @@ Plotly.prototype.saveImage = function (figure, path, callback) {
         } else {
           var image = JSON.parse(body).payload;
           writeFile(path, image, function (err) {
-            if (err) callback(err);
-            console.log('image saved!');
-          })
+            if (err) return callback(err);
+						callback(null);
+          });
         }
       });
     }
@@ -216,7 +222,7 @@ Plotly.prototype.saveImage = function (figure, path, callback) {
 
   req.write(figure);
   req.end();
-}
+};
 
 
 // helper fn to create folders if they don't exist in the path

--- a/index.js
+++ b/index.js
@@ -176,12 +176,12 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
 
 Plotly.prototype.saveImage = function (figure, path, callback) {
   var self = this;
-	if(!callback) {
-		callback = function(err) {
-			if(err) { console.error(err); }
-			else { console.log('image saved!') ;}
-		};
-	}
+  if(!callback) {
+    callback = function(err) {
+      if(err) { console.error(err); }
+      else { console.log('image saved!') ;}
+    };
+  }
   figure = JSON.stringify(figure);
 
   var headers = {
@@ -213,7 +213,7 @@ Plotly.prototype.saveImage = function (figure, path, callback) {
           var image = JSON.parse(body).payload;
           writeFile(path, image, function (err) {
             if (err) return callback(err);
-						callback(null);
+            callback(null);
           });
         }
       });


### PR DESCRIPTION
Previously saveImage only called the callback when it failed.  
It also did not check if the callback existed before trying to use it, even though it is an optional parameter.