### PR TITLE
actually return errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,10 @@ Plotly.prototype.plot = function(data, graphOptions, callback) {
         self.streamHost = url.parse(body['stream-host']).hostname;
       }
       if ( body.error.length > 0 ) {
-        callback({msg: body.error, body: body, statusCode: res.statusCode});
+        var error = new Error(body.error);
+        error.body = body;
+        error.statusCode = res.statusCode;
+        callback(error);
       } else {
         callback(null, {
           streamstatus : body['stream-status'],
@@ -125,7 +128,9 @@ Plotly.prototype.stream = function(token, callback) {
   var stream = http.request(options, function(res) {
     var message = jsonStatus[res.statusCode];
     if (res.statusCode !== 200) {
-      callback({msg : message, statusCode: res.statusCode});
+      var error = new Error(message);
+      error.statusCode = res.statusCode;
+      callback(error);
     } else {
       callback(null, {msg : message, statusCode: res.statusCode});
     }
@@ -198,7 +203,8 @@ Plotly.prototype.saveImage = function (figure, path, callback) {
 
   var req = https.request(options, function (res) {
     if (res.statusCode !== 200) {
-      callback(res.statusCode);
+      var error = new Error('Bad response status code ' + res.statusCode);
+      callback(error);
     } else {
       parseRes(res, function (err, body) {
         if (err) {
@@ -244,7 +250,7 @@ function parseRes (res, cb) {
       res.connection.destroy();
       res.writeHead(413, {'Content-Type': 'text/plain'});
       res.end("req body too large");
-      return cb("body overflow");
+      return cb(new Error("body overflow"));
     }
   });
 


### PR DESCRIPTION
Just about every callback in the Node world returns a parameter called `error` to the callback function. `error` is expected to be an instance of some _Error_, so I tried to apply this expectation to this module:

``` js
var plotly = require('plotly')('kenany', 'blah');

var data = [{x: [0, 1, 2], y: [3, 2, 1], type: 'bar'}];
var graphOptions = {fileopt: 'extend', filename: 'nodenodenode'};

plotly.plot(data, graphOptions, function(error, msg) {
  if (error) {
    throw error;
  }

  console.log(msg);
});
```

When I do get an `error` above, though, what is thrown by the `throw` statement is a plain _Object_. This is completely against the expectation that `error` is, well, an _Error_.

Diving into this module's code, I discovered that this issue becomes even worse upon the realization that this module can return **4 different types** of errors:
- [line 80](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L80) - _Object_ returned
- [line 96](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L96) - _Error_ returned
- [line 128](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L128) - _Object_ returned
- [line 165](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L165) - _Error_ returned
- [line 201](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L201) - **_Number_ returned?!**
- [line 205](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L205) - **_String_ returned?!**
- [line 209](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L209) - _Error_ returned
- [line 255](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L225) - _Error_ returned
- [line 247](https://github.com/plotly/plotly-nodejs/blob/a8affc38091d9d2d896437601004a252ea95ffdb/index.js#L247) - **_String_ returned?!**

So, even if I wanted to just deal with the fact that `error` above is an _Object_, I also have to account for the fact that `error` could be a _String_ or even a _Number_!

This patch makes it so that all `errors` are actually an instance of _Error_.
