### PR TITLE
handle request errors for `getFigure`, `getImage` and `stream`

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,10 @@ Plotly.prototype.stream = function(token, callback) {
         }
     });
 
+    stream.on('error', function (err) {
+        callback(err);
+    });
+
     if (stream.setTimeout) stream.setTimeout(Math.pow(2, 32) * 1000);
 
     return stream;
@@ -173,6 +177,10 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
                 callback(null, figure);
             }
         });
+    });
+
+    req.on('error', function (err) {
+        callback(err);
     });
 
     req.end();
@@ -219,6 +227,11 @@ Plotly.prototype.getImage = function (figure, opts, callback) {
     }
 
     var req = https.request(options, handleResponse);
+
+    req.on('error', function (err) {
+        callback(err);
+    });
+
     req.write(payload);
     req.end();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotly",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple node.js wrapper for the plot.ly API",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
### Resolves: https://github.com/plotly/plotly-nodejs/issues/31

@etpinard @bpostlethwaite 

Solves the issue where we weren't properly handling request errors for `getFigure`, `getImage` and `stream` requests.

This passes the error back to the callback.

