### PR TITLE
Ensure UTF-8 characters are encoded in \u0XXX notation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var https = require('https');
 var http = require('http');
 var jsonStatus = require('./statusmsgs.json');
 var url = require('url');
+var asciiJSON = require('ascii-json');
 
 module.exports = Plotly;
 
@@ -41,8 +42,8 @@ Plotly.prototype.plot = function(data, graphOptions, callback) {
     var pack = {
         'platform': self.platform,
         'version': self.version,
-        'args': JSON.stringify(data),
-        'kwargs': JSON.stringify(graphOptions),
+        'args': asciiJSON.stringify(data),
+        'kwargs': asciiJSON.stringify(graphOptions),
         'un': self.username,
         'key': self.apiKey,
         'origin': self.origin
@@ -72,7 +73,7 @@ Plotly.prototype.plot = function(data, graphOptions, callback) {
 
             /* Try to parse the response */
             try {
-                body = JSON.parse(body);
+                body = asciiJSON.parse(body);
             } catch (e) {
                 callback(e);
             }
@@ -178,7 +179,7 @@ Plotly.prototype.getFigure = function (fileOwner, fileId, callback) {
 
             /* Try to parse the response */
             try {
-                body = JSON.parse(body);
+                body = asciiJSON.parse(body);
             } catch (e) {
                 callback(e);
             }
@@ -207,7 +208,7 @@ Plotly.prototype.getImage = function (figure, opts, callback) {
     if (!figure) return new Error('no figure provided!');
 
     var self = this;
-    var payload = JSON.stringify({
+    var payload = asciiJSON.stringify({
         figure: figure,
         format: opts.format || 'png',
         width: opts.width || 700,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Alexander Daniel <alex@lesinstruments.com> (http://lesinstruments.com/)",
   "license": "MIT",
   "dependencies": {
+    "ascii-json": "^0.2.0",
     "mkdirp": "~0.5.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,30 @@ test('getImage, imageserver error', function (t) {
 
 });
 
+test('getImage with UTF characters', function (t) {
+    t.plan(2);
+    var plotly = require('../index')('node-test-account', 'tpmz9ye8hg');
+
+    var trace1 = {
+        x: [1, 2, 3, 4],
+        y: [10, 15, 13, 17],
+        type: 'scatter'
+    };
+
+    var figure = {
+        'data': [trace1],
+        'layout': {
+            'title': 'Title (μ = 0, σ = 1.0)'
+        }
+    };
+
+    plotly.getImage(figure, {}, function (err, imageData) {
+        t.error(err);
+        t.ok(imageData);
+        t.end();
+    });
+});
+
 test('creates a plot with UTF chars in filename', function (t) {
 	t.plan(1);
 


### PR DESCRIPTION
Otherwise the server rejects the request. Fixes #43.