### PR TITLE
Allow both jpg and jpeg as possible file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ plotly.getFigure('fileOwner', 'fileId', function (err, figure) {
 
 ## plotly.getImage(figure[, options, callback])
 `figure` is a JSON object of the graph figure
-`options.format` | `jpg`, `jpeg`, `png`, `pdf`, `eps`, `webp`
+`options.format` | `jpeg`, `png`, `pdf`, `eps`, `webp`
 `options.width` | width in `px` (default : 700)
 `options.height` | height in `px` (default : 500)
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ plotly.getFigure('fileOwner', 'fileId', function (err, figure) {
 
 ## plotly.getImage(figure[, options, callback])
 `figure` is a JSON object of the graph figure
-`options.format` | `jpg`, `png`, `pdf`, `eps`, `webp`
+`options.format` | `jpg`, `jpeg`, `png`, `pdf`, `eps`, `webp`
 `options.width` | width in `px` (default : 700)
 `options.height` | height in `px` (default : 500)
 

--- a/index.js
+++ b/index.js
@@ -207,10 +207,6 @@ Plotly.prototype.getImage = function (figure, opts, callback) {
     if (!figure) return new Error('no figure provided!');
 
     var self = this;
-
-    // allow both jpg and jpeg as file formats
-    if (opts && opts.format === 'jpg') opts.format = 'jpeg';
-
     var payload = JSON.stringify({
         figure: figure,
         format: opts.format || 'png',

--- a/index.js
+++ b/index.js
@@ -207,6 +207,10 @@ Plotly.prototype.getImage = function (figure, opts, callback) {
     if (!figure) return new Error('no figure provided!');
 
     var self = this;
+
+    // allow both jpg and jpeg as file formats
+    if (opts && opts.format === 'jpg') opts.format = 'jpeg';
+
     var payload = JSON.stringify({
         figure: figure,
         format: opts.format || 'png',


### PR DESCRIPTION
I initially intended to simply correct the README, pointing out that the correct option is 'jpeg' and not 'jpg', but allowing both seems friendlier
I understand if y'all don't want ambiguity