### PR TITLE
Fix for obscure issue with https library

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,7 @@ Plotly.prototype.plot = function(data, graphOptions, callback) {
         callback(err);
     });
 
-    req.write(urlencoded);
-    req.end();
+    req.end(urlencoded, 'utf8');
 };
 
 Plotly.prototype.stream = function(token, callback) {


### PR DESCRIPTION
We're encountering an error from the usage of req.end() related to the first argument type. Although it was being called with no argument, this code is considered equivalent in the api and shouldn't have the issue.